### PR TITLE
Fix for Issue26

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1078,9 +1078,12 @@ func parseAddressValue(addressText string) (
 	firstAngleBracket := findUnescaped(addressText, '<', quotes_delim)
 	displayName = base.NoString{}
 	if firstAngleBracket > 0 {
-		// There is a display name present. Let's parse it.
+		// We have an angle bracket, and it's not the first character.
+		// Since we have just trimmed whitespace, this means there must
+		// be a display name.
 		if addressText[0] == '"' {
 			// The display name is within quotations.
+			// So it is comprised of all text until the closing quote.
 			addressText = addressText[1:]
 			nextQuote := strings.Index(addressText, "\"")
 
@@ -1095,8 +1098,12 @@ func parseAddressValue(addressText string) (
 			displayName = base.String{nameField}
 			addressText = addressText[nextQuote+1:]
 		} else {
-			// The display name is unquoted, so match until the next whitespace
-			// character.
+			// The display name is unquoted, so it is comprised of
+			// all text until the opening angle bracket, except surrounding whitespace.
+			// According to the ABNF grammar: display-name   =  *(token LWS)/ quoted-string
+			// there are certain characters the display name cannot contain unless it's quoted,
+			// however we don't check for them here since it doesn't impact parsing.
+			// May as well be lenient.
 			nameField := addressText[:firstAngleBracket]
 			displayName = base.String{strings.TrimSpace(nameField)}
 			addressText = addressText[firstAngleBracket:]

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1076,10 +1076,8 @@ func parseAddressValue(addressText string) (
 	addressText = strings.TrimSpace(addressText)
 
 	firstAngleBracket := findUnescaped(addressText, '<', quotes_delim)
-	firstSpace := findAnyUnescaped(addressText, c_ABNF_WS, quotes_delim, angles_delim)
 	displayName = base.NoString{}
-	if firstAngleBracket != -1 && firstSpace != -1 &&
-		firstSpace < firstAngleBracket {
+	if firstAngleBracket > 0 {
 		// There is a display name present. Let's parse it.
 		if addressText[0] == '"' {
 			// The display name is within quotations.
@@ -1099,9 +1097,9 @@ func parseAddressValue(addressText string) (
 		} else {
 			// The display name is unquoted, so match until the next whitespace
 			// character.
-			nameField := addressText[:firstSpace]
-			displayName = base.String{nameField}
-			addressText = addressText[firstSpace+1:]
+			nameField := addressText[:firstAngleBracket]
+			displayName = base.String{strings.TrimSpace(nameField)}
+			addressText = addressText[firstAngleBracket:]
 		}
 	}
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -384,6 +384,26 @@ func TestToHeaders(t *testing.T) {
 		test{toHeaderInput("To: *"), &toHeaderResult{fail, &base.ToHeader{}}},
 
 		test{toHeaderInput("To: <*>"), &toHeaderResult{fail, &base.ToHeader{}}},
+
+		test{toHeaderInput("To: \"Alice Liddell\"<sip:alice@wonderland.com>"), &toHeaderResult{pass,
+			&base.ToHeader{DisplayName: base.String{"Alice Liddell"},
+				Address: &base.SipUri{false, base.String{"alice"}, base.NoString{}, "wonderland.com", nil, noParams, noParams},
+				Params:  noParams}}},
+
+		test{toHeaderInput("To: Alice Liddell <sip:alice@wonderland.com>"), &toHeaderResult{pass,
+			&base.ToHeader{DisplayName: base.String{"Alice Liddell"},
+				Address: &base.SipUri{false, base.String{"alice"}, base.NoString{}, "wonderland.com", nil, noParams, noParams},
+				Params:  noParams}}},
+
+		test{toHeaderInput("To: Alice Liddell<sip:alice@wonderland.com>"), &toHeaderResult{pass,
+			&base.ToHeader{DisplayName: base.String{"Alice Liddell"},
+				Address: &base.SipUri{false, base.String{"alice"}, base.NoString{}, "wonderland.com", nil, noParams, noParams},
+				Params:  noParams}}},
+
+		test{toHeaderInput("To: Alice<sip:alice@wonderland.com>"), &toHeaderResult{pass,
+			&base.ToHeader{DisplayName: base.String{"Alice"},
+				Address: &base.SipUri{false, base.String{"alice"}, base.NoString{}, "wonderland.com", nil, noParams, noParams},
+				Params:  noParams}}},
 	}, t)
 }
 


### PR DESCRIPTION
Fixed issue 26 and added tests to prove it.
In fact, the behaviour was worse than stated.

Our parser always only read an unquoted display name up until the first space.  However looks to me like the ABNF grammar specifies it may contain spaces.

```
name-addr      =  [ display-name ] LAQUOT addr-spec RAQUOT
addr-spec      =  SIP-URI / SIPS-URI / absoluteURI
display-name   =  *(token LWS)/ quoted-string
```

This is also fixed by this pull request.